### PR TITLE
Fix access to invalid iterator (w/ C++11 feature)

### DIFF
--- a/simulte/src/stack/mac/scheduler/LteSchedulerEnbUl.cc
+++ b/simulte/src/stack/mac/scheduler/LteSchedulerEnbUl.cc
@@ -137,18 +137,18 @@ LteSchedulerEnbUl::rtxschedule()
 
         HarqRxBuffers::iterator it= harqRxBuffers_->begin() , et=harqRxBuffers_->end();
 
-        for(; it != et; ++it)
+        for(; it != et; )
         {
             // get current nodeId
             MacNodeId nodeId = it->first;
 
             if(nodeId == 0){	// HACK
-                harqRxBuffers_->erase(nodeId);
+                it = harqRxBuffers_->erase(it);
                 continue;
             }
             OmnetId id = getBinder()->getOmnetId(nodeId);
             if(id == 0){
-                harqRxBuffers_->erase(nodeId);
+                it = harqRxBuffers_->erase(it);
                 continue;
             }
 
@@ -179,6 +179,7 @@ LteSchedulerEnbUl::rtxschedule()
                 }
             }
             EV << NOW << "LteSchedulerEnbUl::rtxschedule user " << nodeId << " allocated bytes : " << allocatedBytes << endl;
+            ++it;
         }
 
         int availableBlocks = allocator_->computeTotalRbs();


### PR DESCRIPTION
Erasing the element invalidates the iterator, which may cause segmentation fault at "++it".
The workaround here is C++ 11 only. In C++ 98 erase(iterator) returns nothing so it will not work.

Solution in C++98 might be keeping the invalid nodeId in an array and removing them after the loop body.
